### PR TITLE
chore: configure Dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    assignees:
+      - "glandais"
+    commit-message:
+      prefix: "deps(maven)"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Adds a standard Dependabot configuration covering the following ecosystems:

- **maven** (`/`): weekly on Monday at 09:00 Europe/Paris, limit 5 PRs, grouped minor+patch updates

Assignee: glandais. Commit prefix: `deps(maven)`. Label: `dependencies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)