### PR TITLE
ci: add PR checks workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,16 @@
+name: PR Checks
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+          cache: maven
+      - run: mvn -B -ntp verify


### PR DESCRIPTION
Adds a \`pull_request\`-triggered CI workflow so Dependabot PRs (and others) are built and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)